### PR TITLE
Update FileLayout.php

### DIFF
--- a/libraries/src/Layout/FileLayout.php
+++ b/libraries/src/Layout/FileLayout.php
@@ -77,7 +77,7 @@ class FileLayout extends BaseLayout
 		$this->setOptions($options);
 
 		// Main properties
-		$this->setLayout($layoutId);
+		$this->setLayoutId($layoutId);
 		$this->basePath = $basePath;
 
 		// Init Enviroment
@@ -470,7 +470,7 @@ class FileLayout extends BaseLayout
 		$this->options->set('component', $component);
 
 		// Refresh include paths
-		$this->refreshIncludePaths();
+		$this->clearIncludePaths();
 	}
 
 	/**
@@ -505,7 +505,7 @@ class FileLayout extends BaseLayout
 		$this->options->set('client', $client);
 
 		// Refresh include paths
-		$this->refreshIncludePaths();
+		$this->clearIncludePaths();
 	}
 
 	/**


### PR DESCRIPTION
From deprecated.php
This "Functions that are deleted when switching to version 4.0".  Repeated many times.

Joomla\CMS\Layout\FileLayout::setLayout() is deprecated, use FileLayout::setLayoutId() instead.
Joomla\CMS\Layout\FileLayout::refreshIncludePaths() is deprecated, use FileLayout::clearIncludePaths() instead.

Pull Request for Issue # .

### Summary of Changes
Now using the recommended methods


### Testing Instructions
With a fresh 3.8.3 enabled log deprecated API logging
switch to site once
check log in administrator/logs/deprecated.php
Install patch

switch to site once
check log in administrator/logs/deprecated.php

### Expected result
No log entry from this file


### Actual result
2017-12-26T08:15:40+00:00	WARNING ::1	deprecated	Joomla\CMS\Layout\FileLayout::setLayout() is deprecated, use FileLayout::setLayoutId() instead.
2017-12-26T08:15:40+00:00	WARNING ::1	deprecated	Joomla\CMS\Layout\FileLayout::refreshIncludePaths() is deprecated, use FileLayout::clearIncludePaths() instead.
2017-12-26T08:15:40+00:00	WARNING ::1	deprecated	Joomla\CMS\Layout\FileLayout::refreshIncludePaths() is deprecated, use FileLayout::clearIncludePaths() instead.


### Documentation Changes Required
No
